### PR TITLE
chore: update Slack link

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
           key: 'Discussions',
           data: [{
             value: 'We are on Slack.',
-            href: 'https://w3cdistributedtracing.slack.com/'
+            href: 'https://w3ccommunity.slack.com/archives/C06KAH5S5RN'
           }]
         }]
       };


### PR DESCRIPTION
We discontinued the old Slack workspace quite a while ago, moving discussion to the W3C community Slack workspace.